### PR TITLE
Set error highlighting on keyword options 

### DIFF
--- a/syntax/i3config.vim
+++ b/syntax/i3config.vim
@@ -2,8 +2,8 @@
 " Language: i3 config file
 " Original Author: Josef Litos (JosefLitos/i3config.vim)
 " Maintainer: Quentin Hibon (github user hiqua)
-" Version: 1.0.2
-" Last Change: 2023-10-26
+" Version: 1.0.3
+" Last Change: 2023-10-31
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -28,26 +28,29 @@ syn match i3ConfigSeparator /[,;\\]/ contained
 syn match i3ConfigParen /[{}]/ contained
 syn keyword i3ConfigBoolean yes no enabled disabled on off true false contained
 " String in simpler (matchable end) and more robust (includes `extend` keyword) forms
-syn match i3ConfigString /\(["']\)[^\\"')\]}]*\1/ contained contains=i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigNumber,i3ConfigVariable,i3ConfigExecAction
-syn region i3ConfigString start=/"[^\\"')\]}]*[\\')\]}]/ skip=/\\\@<=\("\|$\)/ end=/"\|$/ contained contains=i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigNumber,i3ConfigVariable,i3ConfigExecAction keepend extend
-syn region i3ConfigString start=/'[^\\"')\]}]*[\\")\]}]/ skip=/\\\@<=$/ end=/'\|$/ contained contains=i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigNumber,i3ConfigVariable,i3ConfigExecAction keepend extend
+syn match i3ConfigString /\(["']\)[^\\"')\]}]*\1/ contained contains=i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,@i3ConfigNumVar,i3ConfigExecAction
+syn region i3ConfigString start=/"[^\\"')\]}]*[\\')\]}]/ skip=/\\\@<=\("\|$\)/ end=/"\|$/ contained contains=i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,@i3ConfigNumVar,i3ConfigExecAction keepend extend
+syn region i3ConfigString start=/'[^\\"')\]}]*[\\")\]}]/ skip=/\\\@<=$/ end=/'\|$/ contained contains=i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,@i3ConfigNumVar,i3ConfigExecAction keepend extend
 syn match i3ConfigColor /#[0-9A-Fa-f]\{3,8}/ contained
 syn match i3ConfigNumber /[0-9A-Za-z_$-]\@<!-\?\d\+\w\@!/ contained
+" Grouping of common usages
+syn cluster i3ConfigStrVar contains=i3ConfigString,i3ConfigVariable
+syn cluster i3ConfigNumVar contains=i3ConfigNumber,i3ConfigVariable
+syn cluster i3ConfigIdent contains=i3ConfigString,i3ConfigNumber,i3ConfigVariable
+syn cluster i3ConfigValue contains=@i3ConfigIdent,i3ConfigBoolean
 
 " 4.1 Include directive
-syn keyword i3ConfigIncludeKeyword include contained
-syn match i3ConfigIncludeCommand /`[^`]*`/ contained contains=i3ConfigShDelim,i3ConfigShParam,i3ConfigShOper,i3ConfigShCommand,i3ConfigString
-syn match i3ConfigParamLine /^include .*$/ contains=i3ConfigIncludeKeyword,i3ConfigString,i3ConfigVariable,i3ConfigIncludeCommand,i3ConfigShOper
+syn match i3ConfigIncludeCommand /`[^`]*`/ contained contains=@i3ConfigSh
+syn region i3ConfigParamLine matchgroup=i3ConfigKeyword start=/^include / end=/$/ contains=@i3ConfigStrVar,i3ConfigIncludeCommand,i3ConfigShOper keepend
 
 " 4.2 Comments
 syn match i3ConfigComment /^\s*#.*$/ contains=i3ConfigTodo
 
 " 4.3 Fonts
-syn keyword i3ConfigFontKeyword font contained
 syn match i3ConfigColonOperator /:/ contained
 syn match i3ConfigFontNamespace /\w\+:/ contained contains=i3ConfigColonOperator
 syn match i3ConfigFontSize / \d\+\(px\)\?\s\?$/ contained
-syn region i3ConfigFont start=/^\s*font / skip=/\\$/ end=/$/ contains=i3ConfigFontKeyword,i3ConfigFontNamespace,i3ConfigFontSize,i3ConfigSeparator keepend
+syn region i3ConfigParamLine matchgroup=i3ConfigKeyword start=/^\s*font / skip=/\\$/ end=/$/ contains=i3ConfigFontNamespace,i3ConfigFontSize,i3ConfigSeparator keepend containedin=i3ConfigBarBlock
 
 " 4.4-4.5 Keyboard/Mouse bindings
 syn keyword i3ConfigBindKeyword bindsym bindcode contained
@@ -56,10 +59,11 @@ syn match i3ConfigBindModifier /+/ contained
 syn keyword i3ConfigBindModkey Ctrl Shift Mod1 Mod2 Mod3 Mod4 Mod5 contained
 syn match i3ConfigBindCombo /[$0-9A-Za-z_+]\+ / contained contains=i3ConfigBindModifier,i3ConfigVariable,i3ConfigBindModkey
 syn match i3ConfigBindComboLine /bind\(sym\|code\)\( --[a-z-]\+\)* [$0-9A-Za-z_+]\+ / contained contains=i3ConfigBindKeyword,i3ConfigBindArgument,i3ConfigBindCombo
-syn region i3ConfigBind start=/^\s*bind\(sym\|code\) / skip=/\\$/ end=/$/ contains=i3ConfigBindComboLine,i3ConfigCriteria,i3ConfigAction,i3ConfigSeparator,i3ConfigActionKeyword,i3ConfigOption,i3ConfigString,i3ConfigNumber,i3ConfigVariable,i3ConfigBoolean keepend
+syn cluster i3ConfigBinder contains=i3ConfigCriteria,@i3ConfigCommand,i3ConfigSeparator
+syn region i3ConfigBind start=/^\s*bind\(sym\|code\) / skip=/\\$/ end=/$/ contains=i3ConfigBindComboLine,@i3ConfigBinder keepend
 
 " 4.6 Binding modes
-syn region i3ConfigKeyword start=/^mode\( --pango_markup\)\? \([^'" {]\+\|'[^']\+'\|".\+"\)\s\+{$/ end=/^\s*}$/ contains=i3ConfigShParam,i3ConfigString,i3ConfigBind,i3ConfigComment,i3ConfigNumber,i3ConfigParen,i3ConfigVariable fold keepend extend
+syn region i3ConfigKeyword start=/^mode\( --pango_markup\)\? \([^'" {]\+\|'[^']\+'\|".\+"\)\s\+{$/ end=/^\s*}$/ contains=i3ConfigShParam,@i3ConfigStrVar,i3ConfigBind,i3ConfigComment,i3ConfigParen fold keepend extend
 
 " 4.7 Floating modifier
 syn match i3ConfigKeyword /^floating_modifier [$0-9A-Za-z]*$/ contains=i3ConfigVariable,i3ConfigBindModkey
@@ -83,7 +87,7 @@ syn match i3ConfigKeyword /^title_align .*$/ contains=i3ConfigTitleAlignOpts
 
 " 4.12 Border style
 syn keyword i3ConfigBorderOpts none normal pixel contained
-syn match i3ConfigKeyword /^default\(_floating\)\?_border .*$/ contains=i3ConfigBorderOpts,i3ConfigNumber,i3ConfigVariable
+syn match i3ConfigKeyword /^default\(_floating\)\?_border .*$/ contains=i3ConfigBorderOpts,@i3ConfigNumVar
 
 " 4.13 Hide edge borders
 syn keyword i3ConfigEdgeOpts none vertical horizontal both smart smart_no_gaps contained
@@ -102,32 +106,32 @@ syn match i3ConfigKeyword /^no_focus .*$/ contains=i3ConfigCondition
 " 4.17 Variables
 syn match i3ConfigVariable /\$[0-9A-Za-z_:|[\]-]\+/
 syn keyword i3ConfigSetKeyword set contained
-syn match i3ConfigSet /^set \$.*$/ contains=i3ConfigSetKeyword,i3ConfigVariable,i3ConfigColor,i3ConfigString,i3ConfigNumber,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShParam,i3ConfigShOper,i3ConfigBindModkey
+syn match i3ConfigSet /^set \$.*$/ contains=i3ConfigSetKeyword,@i3ConfigSh,@i3ConfigValue,i3ConfigColor,i3ConfigBindModkey
 
 " 4.18 X resources
 syn keyword i3ConfigResourceKeyword set_from_resource contained
-syn match i3ConfigParamLine /^set_from_resource\s\+.*$/ contains=i3ConfigResourceKeyword,i3ConfigCondition,i3ConfigColor,i3ConfigVariable,i3ConfigString,i3ConfigNumber
+syn match i3ConfigParamLine /^set_from_resource\s\+.*$/ contains=i3ConfigResourceKeyword,i3ConfigCondition,i3ConfigColor,@i3ConfigIdent
 
 " 4.19 Assign clients to workspaces
 syn keyword i3ConfigAssignKeyword assign contained
 syn match i3ConfigAssignSpecial /→\|number/ contained
-syn match i3ConfigAssign /^assign .*$/ contains=i3ConfigAssignKeyword,i3ConfigAssignSpecial,i3ConfigCondition,i3ConfigVariable,i3ConfigString,i3ConfigNumber
+syn match i3ConfigAssign /^assign .*$/ contains=i3ConfigAssignKeyword,i3ConfigAssignSpecial,i3ConfigCondition,@i3ConfigIdent
 
 " 4.20 Executing shell commands
 syn keyword i3ConfigExecKeyword exec contained
 syn keyword i3ConfigExecAlwaysKeyword exec_always contained
-syn match i3ConfigShCmdDelim /\$(/ contained
-syn region i3ConfigShCommand start=/\$(/ end=/)/ contained contains=i3ConfigShCmdDelim,i3ConfigExecAction,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigString,i3ConfigNumber,i3ConfigVariable keepend extend
+syn region i3ConfigShCommand matchgroup=i3ConfigShDelim start=/\$(/ end=/)/ contained contains=i3ConfigExecAction,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigString,i3ConfigNumber,i3ConfigVariable extend
 syn match  i3ConfigShDelim /[[\]{}();`]\+/ contained
 syn match  i3ConfigShOper /[<>&|+=~^*!.?]\+/ contained
-syn match i3ConfigShParam /\<-[A-Za-z-][0-9A-Za-z_-]*\>/ contained containedin=i3ConfigVar
-syn region i3ConfigExec start=/^\s*exec\(_always\)\?\( --no-startup-id\)\? [^{]/ skip=/\\$/ end=/$/ contains=i3ConfigExecKeyword,i3ConfigExecAlwaysKeyword,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigNumber,i3ConfigString,i3ConfigVariable,i3ConfigExecAction keepend
+syn match i3ConfigShParam /\<-[A-Za-z-][0-9A-Za-z_-]*\>/ contained
+syn cluster i3ConfigSh contains=@i3ConfigIdent,i3ConfigShOper,i3ConfigShDelim,i3ConfigShParam,i3ConfigShCommand
+syn region i3ConfigExec start=/^\s*exec\(_always\)\?\( --no-startup-id\)\? [^{]/ skip=/\\$/ end=/$/ contains=i3ConfigExecKeyword,i3ConfigExecAlwaysKeyword,i3ConfigExecAction,@i3ConfigSh keepend
 
 " 4.21 Workspaces per output
 syn keyword i3ConfigWorkspaceKeyword workspace contained
 syn keyword i3ConfigWorkspaceOutput output contained
 syn keyword i3ConfigWorkspaceDir prev next back_and_forth number contained
-syn region i3ConfigWorkspaceLine start=/^workspace / skip=/\\$/ end=/$/ contains=i3ConfigWorkspaceKeyword,i3ConfigNumber,i3ConfigString,i3ConfigGaps,i3ConfigWorkspaceOutput,i3ConfigVariable,i3ConfigBoolean,i3ConfigSeparator keepend
+syn region i3ConfigWorkspaceLine start=/^workspace / skip=/\\$/ end=/$/ contains=i3ConfigWorkspaceKeyword,i3ConfigGaps,i3ConfigWorkspaceOutput,@i3ConfigIdent,i3ConfigBoolean,i3ConfigSeparator keepend
 
 " 4.22 Changing colors
 syn match i3ConfigDotOperator /\./ contained
@@ -135,8 +139,7 @@ syn keyword i3ConfigClientOpts focused focused_inactive unfocused urgent placeho
 syn match i3ConfigKeyword /^client\..*$/ contains=i3ConfigDotOperator,i3ConfigClientOpts,i3ConfigColor,i3ConfigVariable
 
 " 4.23 Interprocess communication
-syn match i3ConfigIpcKeyword /ipc-socket/ contained
-syn match i3ConfigParamLine /^ipc-socket .*$/ contains=i3ConfigIpcKeyword
+syn region i3ConfigParamLine matchgroup=i3ConfigKeyword start=/^ipc-socket / end=/$/ contains=i3ConfigNumber
 
 " 4.24 Focus follows mouse
 syn keyword i3ConfigFocusFollowsMouseOpts always contained
@@ -177,7 +180,7 @@ syn match i3ConfigKeyword /^tiling_drag\( off\|\( modifier\| titlebar\)\{1,2\}\)
 
 " 4.35 Gaps
 syn keyword i3ConfigGapsOpts inner outer horizontal vertical left right top bottom current all set plus minus toggle contained
-syn region i3ConfigGaps start=/gaps/ skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigGapsOpts,i3ConfigNumber,i3ConfigVariable,i3ConfigSeparator keepend
+syn region i3ConfigGaps start=/gaps/ skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigGapsOpts,@i3ConfigNumVar,i3ConfigSeparator keepend
 syn match i3ConfigGapsLine /^gaps .*$/ contains=i3ConfigGaps
 syn keyword i3ConfigSmartGapOpts inverse_outer contained
 syn match i3ConfigKeyword /^smart_gaps \(on\|off\|inverse_outer\)$/ contains=i3ConfigSmartGapOpts,i3ConfigBoolean
@@ -186,7 +189,7 @@ syn match i3ConfigKeyword /^smart_gaps \(on\|off\|inverse_outer\)$/ contains=i3C
 syn match i3ConfigBarModifier /^\s\+modifier \S\+$/ contained contains=i3ConfigBindModifier,i3ConfigVariable,i3ConfigBindModkey,i3ConfigBarOptVals
 syn keyword i3ConfigBarOpts bar i3bar_command status_command mode hidden_state id position output tray_output tray_padding separator_symbol workspace_buttons workspace_min_width strip_workspace_numbers strip_workspace_name binding_mode_indicator padding contained
 syn keyword i3ConfigBarOptVals dock hide invisible show none top bottom primary nonprimary contained
-syn region i3ConfigBarBlock start=/^bar {$/ end=/^}$/ contains=i3ConfigBarOpts,i3ConfigBarOptVals,i3ConfigBarModifier,i3ConfigBind,i3ConfigString,i3ConfigComment,i3ConfigFont,i3ConfigBoolean,i3ConfigNumber,i3ConfigParen,i3ConfigColor,i3ConfigVariable,i3ConfigColorsBlock,i3ConfigShOper,i3ConfigShCommand fold keepend extend
+syn region i3ConfigBarBlock start=/^bar {$/ end=/^}$/ contains=i3ConfigBarOpts,i3ConfigBarOptVals,i3ConfigBarModifier,i3ConfigBind,@i3ConfigSh,@i3ConfigValue,i3ConfigComment,i3ConfigColorsBlock fold keepend extend
 
 " 5.16 Color block
 syn keyword i3ConfigColorsKeyword colors contained
@@ -196,16 +199,17 @@ syn region i3ConfigColorsBlock start=/^\s\+colors {$/ end=/^\s\+}$/ contained co
 " 6.0 Command criteria
 syn keyword i3ConfigConditionProp class instance window_role window_type machine id title urgent workspace con_mark con_id floating_from tiling_from contained
 syn keyword i3ConfigConditionSpecial __focused__ all floating tiling contained
-syn region i3ConfigCondition start=/\[/ end=/\]/ contained contains=i3ConfigShDelim,i3ConfigConditionProp,i3ConfigShOper,i3ConfigConditionSpecial,i3ConfigNumber,i3ConfigString keepend extend
-syn region i3ConfigCriteria start=/\[/ skip=/\\$/ end=/\(;\|$\)/ contained contains=i3ConfigCondition,i3ConfigAction,i3ConfigActionKeyword,i3ConfigOption,i3ConfigBoolean,i3ConfigNumber,i3ConfigVariable,i3ConfigSeparator keepend transparent
+syn region i3ConfigCondition start=/\[/ end=/\]/ contained contains=i3ConfigShDelim,i3ConfigConditionProp,i3ConfigShOper,i3ConfigConditionSpecial,@i3ConfigIdent keepend extend
+syn region i3ConfigCriteria start=/\[/ skip=/\\$/ end=/\(;\|$\)/ contained contains=i3ConfigCondition,@i3ConfigCommand,i3ConfigSeparator keepend transparent
 
 " 6.1 Actions through shell
 syn match i3ConfigExecActionKeyword /i3-msg/ contained
-syn region i3ConfigExecAction start=/[a-z3-]\+msg "/ skip=/ "\|\\$/ end=/"\|$/ contained contains=i3ConfigExecActionKeyword,i3ConfigShCommand,i3ConfigNumber,i3ConfigShOper,i3ConfigCriteria,i3ConfigAction,i3ConfigActionKeyword,i3ConfigOption,i3ConfigVariable keepend extend
-syn region i3ConfigExecAction start=/[a-z3-]\+msg '/ skip=/ '\|\\$/ end=/'\|$/ contained contains=i3ConfigExecActionKeyword,i3ConfigShCommand,i3ConfigNumber,i3ConfigShOper,i3ConfigCriteria,i3ConfigAction,i3ConfigActionKeyword,i3ConfigOption,i3ConfigVariable keepend extend
-syn region i3ConfigExecAction start=/[a-z3-]\+msg ['"-]\@!/ skip=/\\$/ end=/[&|;})'"]\@=\|$/ contained contains=i3ConfigExecActionKeyword,i3ConfigShCommand,i3ConfigNumber,i3ConfigShOper,i3ConfigCriteria,i3ConfigAction,i3ConfigActionKeyword,i3ConfigOption,i3ConfigVariable keepend extend
+syn cluster i3ConfigExecActionVal contains=i3ConfigExecActionKeyword,i3ConfigCriteria,i3ConfigAction,i3ConfigActionKeyword,i3ConfigOption,@i3ConfigNumVar
+syn region i3ConfigExecAction start=/[a-z3-]\+msg "/ skip=/ "\|\\$/ end=/"\|$/ contained contains=i3ConfigExecActionKeyword,@i3ConfigExecActionVal keepend extend
+syn region i3ConfigExecAction start=/[a-z3-]\+msg '/ skip=/ '\|\\$/ end=/'\|$/ contained contains=i3ConfigExecActionKeyword,@i3ConfigExecActionVal keepend extend
+syn region i3ConfigExecAction start=/[a-z3-]\+msg ['"-]\@!/ skip=/\\$/ end=/[&|;})'"]\@=\|$/ contained contains=i3ConfigExecActionKeyword,@i3ConfigExecActionVal keepend extend
 " 6.1 Executing applications (4.20)
-syn region i3ConfigAction start=/exec/ skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigExecKeyword,i3ConfigExecAction,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigNumber,i3ConfigString,i3ConfigVariable,i3ConfigSeparator keepend
+syn region i3ConfigAction start=/exec/ skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigExecKeyword,i3ConfigExecAction,@i3ConfigSh,i3ConfigSeparator keepend
 
 " 6.3 Manipulating layout
 syn keyword i3ConfigLayoutKeyword layout contained
@@ -216,23 +220,23 @@ syn region i3ConfigAction start=/layout/ skip=/\\$/ end=/[,;]\|$/ contained cont
 syn keyword i3ConfigFocusKeyword focus contained
 syn keyword i3ConfigFocusOpts left right up down parent child next prev sibling floating tiling mode_toggle contained
 syn keyword i3ConfigFocusOutputOpts left right down up current primary nonprimary next prev contained
-syn region i3ConfigFocusOutput start=/ output / skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigWorkspaceOutput,i3ConfigFocusOutputOpts,i3ConfigString,i3ConfigNumber,i3ConfigSeparator keepend
+syn region i3ConfigFocusOutput start=/ output / skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigWorkspaceOutput,i3ConfigFocusOutputOpts,@i3ConfigIdent,i3ConfigSeparator keepend
 syn match i3ConfigFocusOutputLine /^focus output .*$/ contains=i3ConfigFocusKeyword,i3ConfigFocusOutput
-syn region i3ConfigAction start=/focus/ skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigFocusKeyword,i3ConfigFocusOpts,i3ConfigFocusOutput,i3ConfigString,i3ConfigSeparator keepend transparent
+syn region i3ConfigAction start=/focus/ skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigFocusKeyword,i3ConfigFocusOpts,i3ConfigFocusOutput,i3ConfigSeparator keepend transparent
 
 " 6.8 Focusing workspaces (4.21)
-syn region i3ConfigAction start=/workspace / skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigWorkspaceKeyword,i3ConfigWorkspaceDir,i3ConfigNumber,i3ConfigString,i3ConfigGaps,i3ConfigWorkspaceOutput,i3ConfigVariable,i3ConfigBoolean,i3ConfigSeparator keepend transparent
+syn region i3ConfigAction start=/workspace / skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigWorkspaceKeyword,i3ConfigWorkspaceDir,@i3ConfigValue,i3ConfigGaps,i3ConfigWorkspaceOutput,i3ConfigSeparator keepend transparent
 
 " 6.8.2 Renaming workspaces
 syn keyword i3ConfigRenameKeyword rename contained
-syn region i3ConfigAction start=/rename workspace/ end=/[,;]\|$/ contained contains=i3ConfigRenameKeyword,i3ConfigMoveDir,i3ConfigMoveType,i3ConfigNumber,i3ConfigVariable,i3ConfigString keepend transparent
+syn region i3ConfigAction start=/rename workspace/ end=/[,;]\|$/ contained contains=i3ConfigRenameKeyword,i3ConfigMoveDir,i3ConfigMoveType,@i3ConfigIdent keepend transparent
 
 " 6.5,6.9-6.11 Moving containers
 syn keyword i3ConfigMoveKeyword move contained
 syn keyword i3ConfigMoveDir left right down up position absolute center to current contained
 syn keyword i3ConfigMoveType window container workspace output mark mouse scratchpad contained
 syn match i3ConfigUnit / px\| ppt/ contained
-syn region i3ConfigAction start=/move/ skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigMoveKeyword,i3ConfigMoveDir,i3ConfigMoveType,i3ConfigWorkspaceDir,i3ConfigUnit,i3ConfigNumber,i3ConfigVariable,i3ConfigString,i3ConfigSeparator,i3ConfigShParam keepend transparent
+syn region i3ConfigAction start=/move/ skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigMoveKeyword,i3ConfigMoveDir,i3ConfigMoveType,i3ConfigWorkspaceDir,i3ConfigUnit,@i3ConfigIdent,i3ConfigSeparator,i3ConfigShParam keepend transparent
 
 " 6.12 Resizing containers/windows
 syn keyword i3ConfigResizeKeyword resize contained
@@ -241,7 +245,7 @@ syn region i3ConfigAction start=/resize/ skip=/\\$/ end=/[,;]\|$/ contained cont
 
 " 6.14 VIM-like marks
 syn match i3ConfigMark /mark\( --\(add\|replace\)\( --toggle\)\?\)\?/ contained contains=i3ConfigShParam
-syn region i3ConfigAction start=/\<mark/ skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigMark,i3ConfigNumber,i3ConfigString,i3ConfigSeparator keepend transparent
+syn region i3ConfigAction start=/\<mark/ skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigMark,@i3ConfigIdent,i3ConfigSeparator keepend transparent
 
 " 6.24 Changing gaps (4.35)
 syn region i3ConfigAction start=/gaps/ skip=/\\$/ end=/[,;]\|$/ contained contains=i3ConfigGaps keepend transparent
@@ -249,6 +253,7 @@ syn region i3ConfigAction start=/gaps/ skip=/\\$/ end=/[,;]\|$/ contained contai
 " Commands useable in keybinds
 syn keyword i3ConfigActionKeyword mode append_layout kill open fullscreen sticky split floating swap unmark show_marks title_window_icon title_format border restart reload exit scratchpad nop bar contained
 syn keyword i3ConfigOption default enable disable toggle key restore current horizontal vertical auto none normal pixel show container with id con_id padding hidden_state hide dock invisible contained
+syn cluster i3ConfigCommand contains=i3ConfigAction,i3ConfigActionKeyword,i3ConfigOption,@i3ConfigValue,i3ConfigColor
 
 " Define the highlighting.
 hi def link i3ConfigError                           Error
@@ -263,13 +268,10 @@ hi def link i3ConfigBoolean                         Boolean
 hi def link i3ConfigString                          String
 hi def link i3ConfigColor                           Constant
 hi def link i3ConfigNumber                          Number
-hi def link i3ConfigIncludeKeyword                  i3ConfigKeyword
 hi def link i3ConfigComment                         Comment
-hi def link i3ConfigFontKeyword                     i3ConfigKeyword
 hi def link i3ConfigColonOperator                   i3ConfigOperator
 hi def link i3ConfigFontNamespace                   i3ConfigOption
 hi def link i3ConfigFontSize                        i3ConfigNumber
-hi def link i3ConfigFont                            i3ConfigString
 hi def link i3ConfigBindKeyword                     i3ConfigKeyword
 hi def link i3ConfigBindArgument                    i3ConfigShParam
 hi def link i3ConfigBindModifier                    i3ConfigOperator
@@ -292,14 +294,12 @@ hi def link i3ConfigExecAlwaysKeyword               i3ConfigKeyword
 hi def link i3ConfigShParam                         PreProc
 hi def link i3ConfigShDelim                         Delimiter
 hi def link i3ConfigShOper                          Operator
-hi def link i3ConfigShCmdDelim                      i3ConfigShDelim
 hi def link i3ConfigShCommand                       Normal
 hi def link i3ConfigWorkspaceKeyword                i3ConfigCommand
 hi def link i3ConfigWorkspaceOutput                 i3ConfigMoveType
 hi def link i3ConfigWorkspaceDir                    i3ConfigOption
 hi def link i3ConfigDotOperator                     i3ConfigOperator
 hi def link i3ConfigClientOpts                      i3ConfigOption
-hi def link i3ConfigIpcKeyword                      i3ConfigKeyword
 hi def link i3ConfigFocusFollowsMouseOpts           i3ConfigOption
 hi def link i3ConfigMouseWarpingOpts                i3ConfigOption
 hi def link i3ConfigPopupFullscreenOpts             i3ConfigOption

--- a/syntax/i3config.vim
+++ b/syntax/i3config.vim
@@ -79,7 +79,7 @@ syn match i3ConfigKeyword /^default_orientation \w*$/ contains=i3ConfigOrientati
 
 " 4.10 Layout mode
 syn keyword i3ConfigWorkspaceLayoutOpts default stacking tabbed contained
-syn match i3ConfigKeyword /^workspace_layout \w*$/ contains=i3ConfigWorkspaceLayoutOpts
+syn match i3ConfigKeyword /^workspace_layout \(default\|stacking\|tabbed\)$/ contains=i3ConfigWorkspaceLayoutOpts
 
 " 4.11 Title alignment
 syn keyword i3ConfigTitleAlignOpts left center right contained

--- a/syntax/i3config.vim
+++ b/syntax/i3config.vim
@@ -75,7 +75,7 @@ syn match i3ConfigKeyword /^floating_\(maximum\|minimum\)_size .*$/ contains=i3C
 
 " 4.9 Orientation
 syn keyword i3ConfigOrientationOpts vertical horizontal auto contained
-syn match i3ConfigKeyword /^default_orientation \w*$/ contains=i3ConfigOrientationOpts
+syn match i3ConfigKeyword /^default_orientation \(vertical\|horizontal\|auto\)$/ contains=i3ConfigOrientationOpts
 
 " 4.10 Layout mode
 syn keyword i3ConfigWorkspaceLayoutOpts default stacking tabbed contained

--- a/syntax/swayconfig.vim
+++ b/syntax/swayconfig.vim
@@ -2,8 +2,8 @@
 " Language: sway config file
 " Original Author: Josef Litos (JosefLitos/i3config.vim)
 " Maintainer: James Eapen <james.eapen@vai.org>
-" Version: 1.0.2
-" Last Change: 2023-10-25
+" Version: 1.0.3
+" Last Change: 2023-10-31
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -18,6 +18,9 @@ endif
 
 runtime! syntax/i3config.vim
 
+" Helpers
+syn cluster swayConfigBindCommon contains=@i3ConfigBinder,i3ConfigComment,i3ConfigParen
+
 " i3 extensions
 syn keyword i3ConfigActionKeyword opacity urgent shortcuts_inhibitor splitv splith splitt contained
 syn keyword i3ConfigOption set plus minus allow deny csd v h t contained
@@ -29,17 +32,17 @@ syn keyword i3ConfigWorkspaceDir prev_on_output next_on_output contained
 syn keyword swayConfigBindKeyword bindswitch bindgesture contained
 syn match i3ConfigBindArgument /--\(locked\|to-code\|no-repeat\|input-device=[^ '"]*\|no-warn\)/ contained contains=i3ConfigColonOperator,i3ConfigVariable
 syn match i3ConfigBindComboLine /bind\(sym\|code\)\( --[a-z-]\+\(=\([^ '"]*\|['"][^'"]*['"]\)\)\?\)* [$0-9A-Za-z_+]\+ / contained contains=i3ConfigBindKeyword,i3ConfigBindArgument,i3ConfigBindCombo,i3ConfigString
-syn region i3ConfigBind start=/^\s*bind\(switch\|gesture\) / skip=/\\$/ end=/$/ contains=swayConfigBindKeyword,swayConfigBindswitch,swayConfigBindswitchArgument,swayConfigBindgesture,swayConfigBindgestureArgument,i3ConfigCriteria,i3ConfigAction,i3ConfigSeparator,i3ConfigActionKeyword,i3ConfigOption,i3ConfigString,i3ConfigNumber,i3ConfigVariable,i3ConfigBoolean keepend
+syn region i3ConfigBind start=/^\s*bind\(switch\|gesture\) / skip=/\\$/ end=/$/ contains=swayConfigBindKeyword,swayConfigBindswitch,swayConfigBindswitchArgument,swayConfigBindgesture,swayConfigBindgestureArgument,@i3ConfigBinder keepend
 
 syn match swayConfigBindBlockHeader /^\s*bind\(sym\|code\) .*{$/ contained contains=i3ConfigBindKeyword,i3ConfigBindArgument,i3ConfigParen,i3ConfigString
 syn match swayConfigBindBlockCombo /^\s\+\(--[a-z-]\+ \)*[$a-zA-Z0-9_+]\+ [a-z[]\@=/ contained contains=i3ConfigBindArgument,i3ConfigBindCombo
-syn region i3ConfigBind start=/^\s*bind\(sym\|code\) .*{$/ end=/^\s*}$/ contains=swayConfigBindBlockHeader,swayConfigBindBlockCombo,i3ConfigCriteria,i3ConfigAction,i3ConfigSeparator,i3ConfigActionKeyword,i3ConfigOption,i3ConfigString,i3ConfigNumber,i3ConfigVariable,i3ConfigBoolean,i3ConfigComment,i3ConfigParen fold keepend extend
+syn region i3ConfigBind start=/^\s*bind\(sym\|code\) .*{$/ end=/^\s*}$/ contains=swayConfigBindBlockHeader,swayConfigBindBlockCombo,@swayConfigBindCommon fold keepend extend
 " fix for extra long bindsym blocks that would be parsed incorrectly when scrolling up
-syn region i3ConfigBlockOrphan start=/^\s\+\S/ skip=/^\s\|^$/ end=/^}\?/ contains=swayConfigBindBlockCombo,i3ConfigCriteria,i3ConfigAction,i3ConfigSeparator,i3ConfigActionKeyword,i3ConfigOption,i3ConfigString,i3ConfigNumber,i3ConfigVariable,i3ConfigBoolean,i3ConfigComment,i3ConfigParen keepend extend
+syn region i3ConfigBlockOrphan start=/^\s\+\S/ skip=/^\s\|^$/ end=/^}\?/ contains=swayConfigBindBlockCombo,@swayConfigBindCommon keepend extend
 
 syn keyword i3ConfigClientOpts focused_tab_title contained
 
-syn region swayConfigExecBlock start=/exec\(_always\)\? {/ end=/^}$/ contains=i3ConfigExecKeyword,i3ConfigExecAlwaysKeyword,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigNumber,i3ConfigString,i3ConfigVariable,i3ConfigComment fold keepend extend
+syn region swayConfigExecBlock start=/exec\(_always\)\? {/ end=/^}$/ contains=i3ConfigExecKeyword,i3ConfigExecAlwaysKeyword,@i3ConfigSh,i3ConfigComment fold keepend extend
 
 syn keyword swayConfigFloatingModifierOpts normal inverse contained
 syn match i3ConfigKeyword /^floating_modifier [$a-zA-Z0-9+]\+ \(normal\|inverse\)$/ contains=i3ConfigVariable,i3ConfigBindModkey,swayConfigFloatingModifierOpts
@@ -66,46 +69,47 @@ syn match swayConfigBindswitchArgument /--\(locked\|no-warn\|reload\)/ contained
 syn keyword swayConfigBindswitchType lid tablet contained
 syn keyword swayConfigBindswitchState toggle contained
 syn match swayConfigBindswitch /\(lid\|tablet\):\(on\|off\|toggle\) / contained contains=swayConfigBindswitchType,i3ConfigColonOperator,swayConfigBindswitchState,i3ConfigBoolean
-syn region i3ConfigBind start=/^\s*bindswitch\s\+.*{$/ end=/^\s*}$/ contains=swayConfigBindKeyword,swayConfigBindswitch,swayConfigBindswitchArgument,i3ConfigNumber,i3ConfigVariable,i3ConfigAction,i3ConfigActionKeyword,i3ConfigOption,i3ConfigSeparator,i3ConfigString,i3ConfigCriteria,swayConfigOutputCommand,i3ConfigBoolean,i3ConfigParen,i3ConfigComment fold keepend extend
+syn region i3ConfigBind start=/^\s*bindswitch\s\+.*{$/ end=/^\s*}$/ contains=swayConfigBindKeyword,swayConfigBindswitch,swayConfigBindswitchArgument,swayConfigOutputCommand,@swayConfigBindCommon fold keepend extend
 
 " Bindgesture
 syn match swayConfigBindgestureArgument /--\(exact\|input-device=[:0-9a-zA-Z_/-]\+\|no-warn\)/ contained
 syn keyword swayConfigBindgestureType hold swipe pinch contained
 syn keyword swayConfigBindgestureDir up down left right inward outward clockwise counterclockwise contained
 syn match swayConfigBindgesture /\(hold\(:[1-5]\)\?\|swipe\(:[3-5]\)\?\(:up\|:down\|:left\|:right\)\?\|pinch\(:[2-5]\)\?:\(+\?\(inward\|outward\|clockwise\|counterclockwise\|up\|down\|left\|right\)\)\+\) / contained contains=i3ConfigNumber,swayConfigBindgestureType,i3ConfigColonOperator,swayConfigBindgestureDir,i3ConfigBindModifier
-syn region i3ConfigBind start=/^\s*bindgesture\s\+.*{$/ end=/^\s*}$/ contains=swayConfigBindKeyword,swayConfigBindgesture,swayConfigBindgestureArgument,i3ConfigCriteria,i3ConfigAction,i3ConfigSeparator,i3ConfigActionKeyword,i3ConfigOption,i3ConfigString,i3ConfigNumber,i3ConfigVariable,i3ConfigBoolean,i3ConfigParen,i3ConfigComment fold keepend extend
+syn region i3ConfigBind start=/^\s*bindgesture\s\+.*{$/ end=/^\s*}$/ contains=swayConfigBindKeyword,swayConfigBindgesture,swayConfigBindgestureArgument,@swayConfigBindCommon fold keepend extend
 
 " Tiling drag threshold
 syn match i3ConfigKeyword /^tiling_drag_threshold \d\+$/ contains=i3ConfigNumber
 
 " Titlebar commands
-syn match i3ConfigKeyword /^titlebar_border_thickness \(\d\+\|\$\S\+\)$/ contains=i3ConfigNumber,i3ConfigVariable
-syn match i3ConfigKeyword /^titlebar_padding \(\d\+\|\$\S\+\)\( \d\+\)\?$/ contains=i3ConfigNumber,i3ConfigVariable
+syn match i3ConfigKeyword /^titlebar_border_thickness \(\d\+\|\$\S\+\)$/ contains=@i3ConfigNumVar
+syn match i3ConfigKeyword /^titlebar_padding \(\d\+\|\$\S\+\)\( \d\+\)\?$/ contains=@i3ConfigNumVar
 
 syn match swayConfigDeviceOps /[*,:;]/ contained
+syn cluster swayConfigDeviceLine contains=@i3ConfigValue,swayConfigDeviceOps
+syn cluster swayConfigDeviceBlock contains=@swayConfigDeviceLine,i3ConfigComment,i3ConfigParen
 
 " Input devices
-syn keyword swayConfigInputKeyword input contained
 syn keyword swayConfigInputType touchpad pointer keyboard touch tablet_tool tablet_pad switch contained
 syn match swayConfigInputTypePair /\<type:\w\+\>/ contained contains=i3ConfigColonOperator,swayConfigInputType
-syn region swayConfigInputStart start=/^input / end=/\s/ contained contains=swayConfigInputKeyword,swayConfigInputTypePair,i3ConfigString keepend extend
+syn region swayConfigInputStart matchgroup=i3ConfigCommand start=/^input / end=/\s/ contained contains=swayConfigInputTypePair,@i3ConfigStrVar
 syn keyword swayConfigInputOpts xkb_layout xkb_variant xkb_rules xkb_switch_layout xkb_numlock xkb_file xkb_capslock xkb_model repeat_delay repeat_rate map_to_output map_to_region map_from_region tool_mode accel_profile dwt dwtp drag_lock drag click_method middle_emulation tap events calibration_matrix natural_scroll left_handed pointer_accel scroll_button scroll_factor scroll_method tap_button_map contained
 syn keyword swayConfigInputOptVals absolute relative adaptive flat none button_areas clickfinger toggle two_finger edge on_button_down lrm lmr next prev pen eraser brush pencil airbrush disabled_on_external_mouse disable contained
 syn match swayConfigXkbOptsPairVal /:[0-9a-z_-]\+/ contained contains=i3ConfigColonOperator
 syn match swayConfigXkbOptsPair /[a-z]\+:[0-9a-z_-]\+/ contained contains=swayConfigXkbOptsPairVal
 syn match swayConfigInputXkbOpts /xkb_options \([a-z]\+:[0-9a-z_-]\+,\?\)\+/ contained contains=swayConfigXkbOptsPair,swayConfigDeviceOps
-syn region i3ConfigAction start=/input/ skip=/\\$/ end=/\([,;]\|$\)/ contained contains=swayConfigInputStart,swayConfigInputXkbOpts,swayConfigInputOpts,swayConfigInputOptVals,i3ConfigVariable,i3ConfigNumber,i3ConfigBoolean,swayConfigDeviceOps keepend transparent
-syn region i3ConfigInput start=/^input/ skip=/\\$/ end=/$/ contains=swayConfigInputStart,swayConfigInputXkbOpts,swayConfigInputOpts,swayConfigInputOptVals,i3ConfigVariable,i3ConfigNumber,i3ConfigBoolean,swayConfigDeviceOps keepend
-syn region i3ConfigInput start=/^input .* {/ end=/}$/ contains=swayConfigInputStart,swayConfigInputXkbOpts,swayConfigInputOpts,swayConfigInputOptVals,i3ConfigVariable,i3ConfigNumber,i3ConfigBoolean,swayConfigDeviceOps,i3ConfigParen,i3ConfigComment keepend extend
+syn region i3ConfigAction start=/input/ skip=/\\$/ end=/\([,;]\|$\)/ contained contains=swayConfigInputStart,swayConfigInputXkbOpts,swayConfigInputOpts,swayConfigInputOptVals,@swayConfigDeviceLine keepend transparent
+syn region i3ConfigInput start=/^input/ skip=/\\$/ end=/$/ contains=swayConfigInputStart,swayConfigInputXkbOpts,swayConfigInputOpts,swayConfigInputOptVals,@swayConfigDeviceLine keepend
+syn region i3ConfigInput start=/^input .* {/ end=/}$/ contains=swayConfigInputStart,swayConfigInputXkbOpts,swayConfigInputOpts,swayConfigInputOptVals,@swayConfigDeviceBlock keepend extend
 
 " Seat
 syn keyword swayConfigSeatKeyword seat contained
 syn keyword swayConfigSeatOpts attach cursor fallback hide_cursor idle_inhibit idle_wake keyboard_grouping shortcuts_inhibitor pointer_constraint xcursor_theme contained
 syn match swayConfigSeatOptVals /when-typing/ contained
 syn keyword swayConfigSeatOptVals move set press release none smart activate deactivate toggle escape enable disable contained
-syn region i3ConfigAction start=/seat/ skip=/\\$/ end=/\([,;]\|$\)/ contained contains=swayConfigSeatKeyword,i3ConfigString,i3ConfigNumber,i3ConfigBoolean,swayConfigSeatOptVals,swayConfigSeatOpts,swayConfigDeviceOps,swayConfigInputType keepend transparent
-syn region swayConfigSeat start=/seat/ skip=/\\$/ end=/$/ contains=swayConfigSeatKeyword,i3ConfigString,i3ConfigNumber,i3ConfigBoolean,swayConfigSeatOptVals,swayConfigSeatOpts,swayConfigDeviceOps,swayConfigInputType keepend
-syn region swayConfigSeat start=/seat .* {$/ end=/}$/ contains=swayConfigSeatKeyword,i3ConfigString,i3ConfigNumber,i3ConfigBoolean,swayConfigSeatOptVals,swayConfigSeatOpts,swayConfigDeviceOps,i3ConfigParen,swayConfigInputType,i3ConfigComment keepend extend
+syn region i3ConfigAction start=/seat/ skip=/\\$/ end=/\([,;]\|$\)/ contained contains=swayConfigSeatKeyword,swayConfigSeatOptVals,swayConfigSeatOpts,swayConfigInputType,@swayConfigDeviceLine keepend transparent
+syn region swayConfigSeat start=/seat/ skip=/\\$/ end=/$/ contains=swayConfigSeatKeyword,swayConfigSeatOptVals,swayConfigSeatOpts,swayConfigInputType,@swayConfigDeviceLine keepend
+syn region swayConfigSeat start=/seat .* {$/ end=/}$/ contains=swayConfigSeatKeyword,swayConfigSeatOptVals,swayConfigSeatOpts,swayConfigInputType,@swayConfigDeviceBlock keepend extend
 
 " Output monitors
 syn keyword swayConfigOutputKeyword output contained
@@ -114,9 +118,9 @@ syn keyword swayConfigOutputOptVals linear nearest smart rgb bgr vrgb vbgr none 
 syn match swayConfigOutputOptVals /--custom\|flipped-\(90\|180\|270\)/ contained
 syn match swayConfigOutputFPS /@[0-9.]\+Hz/ contained
 syn match swayConfigOutputMode / [0-9]\+x[0-9]\+\(@[0-9.]\+Hz\)\?/ contained contains=swayConfigOutputFPS
-syn region i3ConfigAction start=/output/ skip=/\\$/ end=/\([,;]\|$\)/ contained contains=swayConfigOutputKeyword,swayConfigOutputMode,swayConfigOutputOpts,swayConfigOutputOptVals,i3ConfigVariable,i3ConfigNumber,i3ConfigString,i3ConfigColor,i3ConfigBoolean,swayConfigDeviceOps keepend transparent
-syn region swayConfigOutput start=/^output/ skip=/\\$/ end=/$/  contains=swayConfigOutputKeyword,swayConfigOutputMode,swayConfigOutputOpts,swayConfigOutputOptVals,i3ConfigVariable,i3ConfigNumber,i3ConfigString,i3ConfigColor,i3ConfigBoolean,swayConfigDeviceOps keepend
-syn region swayConfigOutput start=/^output .* {$/ end=/}$/  contains=swayConfigOutputKeyword,swayConfigOutputMode,swayConfigOutputOpts,swayConfigOutputOptVals,i3ConfigVariable,i3ConfigNumber,i3ConfigString,i3ConfigColor,i3ConfigBoolean,swayConfigDeviceOps,i3ConfigParen,i3ConfigComment keepend extend
+syn region i3ConfigAction start=/output/ skip=/\\$/ end=/\([,;]\|$\)/ contained contains=swayConfigOutputKeyword,swayConfigOutputMode,swayConfigOutputOpts,swayConfigOutputOptVals,@swayConfigDeviceLine,i3ConfigColor keepend transparent
+syn region swayConfigOutput start=/^output/ skip=/\\$/ end=/$/  contains=swayConfigOutputKeyword,swayConfigOutputMode,swayConfigOutputOpts,swayConfigOutputOptVals,@swayConfigDeviceLine,i3ConfigColor keepend
+syn region swayConfigOutput start=/^output .* {$/ end=/}$/  contains=swayConfigOutputKeyword,swayConfigOutputMode,swayConfigOutputOpts,swayConfigOutputOptVals,@swayConfigDeviceBlock,i3ConfigColor keepend extend
 
 " Define the highlighting.
 hi def link swayConfigFloatingModifierOpts   i3ConfigOption
@@ -131,7 +135,6 @@ hi def link swayConfigBindgestureArgument    i3ConfigBindArgument
 hi def link swayConfigBindgestureType        i3ConfigMoveType
 hi def link swayConfigBindgestureDir         i3ConfigMoveDir
 hi def link swayConfigDeviceOps              i3ConfigOperator
-hi def link swayConfigInputKeyword           i3ConfigCommand
 hi def link swayConfigInputType              i3ConfigMoveType
 hi def link swayConfigInputTypePair          i3ConfigMoveDir
 hi def link swayConfigInputOptVals           i3ConfigShParam


### PR DESCRIPTION
`default_orentation` and `workspace_layout` options now error on anything that's not a valid option. I'm not sure how to get the anything that's not in the `contains` block to show up as an error without adding them to the `match` in addition to the `keyword` - if you know how feel free to edit. I'll try fixing a few more of these in the coming weeks.