### PR TITLE
feat: link highlight popup fullscreen opts extra with opts

### DIFF
--- a/syntax/i3config.vim
+++ b/syntax/i3config.vim
@@ -313,7 +313,7 @@ hi def link i3ConfigClientOpts                      i3ConfigOption
 hi def link i3ConfigFocusFollowsMouseOpts           i3ConfigOption
 hi def link i3ConfigMouseWarpingOpts                i3ConfigOption
 hi def link i3ConfigPopupFullscreenOpts             i3ConfigOption
-hi def link i3ConfigPopupFullscreenOptsExtra        i3ConfigOption
+hi def link i3ConfigPopupFullscreenOptsExtra        i3ConfigPopupFullscreenOpts
 hi def link i3ConfigFocusWrappingOpts               i3ConfigOption
 hi def link i3ConfigTimeUnit                        i3ConfigNumber
 hi def link i3ConfigFocusOnActivationOpts           i3ConfigOption

--- a/syntax/i3config.vim
+++ b/syntax/i3config.vim
@@ -151,8 +151,8 @@ syn keyword i3ConfigKeyword mouse_warping contained skipwhite nextgroup=i3Config
 
 " 4.26 Popups while fullscreen
 syn keyword i3ConfigPopupFullscreenOpts smart ignore leave_fullscreen contained
-syn keyword i3ConfigPopupFullscreenExtra all contained
-syn cluster i3ConfigPopupFullscreenOpts contains=i3ConfigPopupFullscreenOpts,i3ConfigPopupFullscreenExtra
+syn keyword i3ConfigPopupFullscreenOptsExtra all contained
+syn cluster i3ConfigPopupFullscreenOpts contains=i3ConfigPopupFullscreenOpts,i3ConfigPopupFullscreenOptsExtra
 syn keyword i3ConfigKeyword popup_during_fullscreen contained skipwhite nextgroup=@i3ConfigPopupFullscreenOpts
 
 " 4.27 Focus wrapping

--- a/syntax/swayconfig.vim
+++ b/syntax/swayconfig.vim
@@ -22,7 +22,7 @@ syn cluster i3ConfigCommand contains=i3ConfigCommand,i3ConfigAction,i3ConfigActi
 runtime! syntax/i3config.vim
 
 " In sway, popup_during_fullscreen does not have options like all option.
-syn cluster i3ConfigPopupFullscreenOpts remove=i3ConfigPopupFullscreenExtra
+syn cluster i3ConfigPopupFullscreenOpts remove=i3ConfigPopupFullscreenOptsExtra
 
 " Sway extensions to i3
 syn keyword i3ConfigActionKeyword opacity urgent shortcuts_inhibitor splitv splith splitt contained contained skipwhite nextgroup=i3ConfigOption


### PR DESCRIPTION
This changes related to the discussion in this PR:
https://github.com/vim/vim/pull/18760

Basically link the highlight for popup fullscreen opts extra with opts so that the user only need to change the highlight for popup fullscreen opts and the opts extra highlight will also effected.

Also, I have noticed that the syntax keyword name for popup fullscreen opts extra is not the same as the highlight default link one. So I changed the syntax keyword name to match the highlight default link name.